### PR TITLE
Change how Packets are handled

### DIFF
--- a/Polaris/PolarisLib/packet/IRecvPacket.cs
+++ b/Polaris/PolarisLib/packet/IRecvPacket.cs
@@ -1,0 +1,8 @@
+﻿namespace PolarisLib.packet
+{
+	/// Packets sent by the client and received by the server
+    interface IRecvPacket
+    {
+		void ParseData(byte[] data);
+	}
+}

--- a/Polaris/PolarisLib/packet/IRecvPacket.cs
+++ b/Polaris/PolarisLib/packet/IRecvPacket.cs
@@ -1,4 +1,4 @@
-﻿namespace PolarisLib.packet
+﻿namespace Polaris.Lib.Packet
 {
 	/// Packets sent by the client and received by the server
     interface IRecvPacket

--- a/Polaris/PolarisLib/packet/ISendPacket.cs
+++ b/Polaris/PolarisLib/packet/ISendPacket.cs
@@ -1,0 +1,10 @@
+﻿using Polaris.Lib.Packet;
+
+namespace PolarisLib.packet
+{
+	/// Packets sent by the server and received by the client
+	interface ISendPacket
+    {
+		byte[] ConstructPacket(PacketHeader header);
+	}
+}

--- a/Polaris/PolarisLib/packet/Packet.cs
+++ b/Polaris/PolarisLib/packet/Packet.cs
@@ -1,26 +1,55 @@
 using System;
+using System.IO;
 
 namespace Polaris.Lib.Packet
 {
-    // TODO: For packets it might be better to use unsafe code and Marshal + packed structures to parse the data out
-    public partial class Packet
-    {
-        public PacketHeader header;
-        public byte[] data;
+	// TODO: For packets it might be better to use unsafe code and Marshal + packed structures to parse the data out
+	public partial class Packet
+	{
+		public PacketHeader header;
+		public byte[] data;
+		public byte[] packet;
 
-        public Packet(byte[] pkt)
-        {
-            this.header = new PacketHeader(pkt);
-            Array.Copy(pkt, 0x8, this.data, 0x0, pkt.Length - 0x8);
-        }
+		/// For when a packet is received
+		public Packet(byte[] packet)
+		{
+			this.packet = packet;
+			this.header = new PacketHeader(packet);
+			Array.Copy(packet, 0x8, this.data, 0x0, packet.Length - 0x8);
+		}
 
-        public ushort TypeToUShort()
-        {
-            return (ushort)((header.type << 8) | header.subType);
-        }
+		/// For when a packet is being sent
+		public Packet(PacketHeader header, byte[] data)
+		{
+			this.header = header;
+			this.data = data;
+			BuildPacket();
+		}
 
-        protected virtual void ParseData(byte[] data)
-        {
-        }
-    }
+		/// Build the packet given a header and data, usually called when constructing a packet to send
+		public void BuildPacket()
+		{
+			this.packet = new byte[header.size];
+			using (BinaryWriter writer = new BinaryWriter(new MemoryStream(this.packet)))
+			{
+				writer.Write(header.size);
+				writer.Write(header.type);
+				writer.Write(header.subType);
+				writer.Write(header.flag1);
+				writer.Write(header.flag2);
+				writer.Write(data);
+			}
+		}
+
+		public Packet()
+		{
+		}
+
+		/// Get PacketID to use with PacketList
+		public ushort GetPacketID()
+		{
+			return (ushort)((header.type << 8) | header.subType);
+		}
+
+	}
 }

--- a/Polaris/PolarisLib/packet/PacketHeader.cs
+++ b/Polaris/PolarisLib/packet/PacketHeader.cs
@@ -2,10 +2,11 @@ using System;
 
 namespace Polaris.Lib.Packet
 {
-    // [Size:4][Type:1][SubType:1][Flag1:1][Flag2:1]
-
-    public class PacketHeader
+	// [Size:4][Type:1][SubType:1][Flag1:1][Flag2:1]
+	public class PacketHeader
     {
+		public const uint HeaderSize = 0x8;
+
         // TODO: Determine if these need to be set to read-only
         public uint size;
         public byte type;

--- a/Polaris/PolarisLib/packet/Packets/PacketDamage.cs
+++ b/Polaris/PolarisLib/packet/Packets/PacketDamage.cs
@@ -25,7 +25,7 @@ namespace Polaris.Lib.Packet
 		public byte[] ConstructPacket(PacketHeader header)
 		{
 			this.header = header;
-			this.data = new byte[0x50 - PacketHeader.HeaderSize];
+			this.data = new byte[this.header.size - PacketHeader.HeaderSize];
 
 			using (BinaryWriter writer = new BinaryWriter(new MemoryStream(this.data)))
 			{

--- a/Polaris/PolarisLib/packet/Packets/PacketDamage.cs
+++ b/Polaris/PolarisLib/packet/Packets/PacketDamage.cs
@@ -1,45 +1,50 @@
-using System;
+using PolarisLib.packet;
 using System.IO;
 
 namespace Polaris.Lib.Packet
 {
-    public class PacketDamage : Packet
-    {
-        public uint playerID; // 0x8 - 0xB
-        public byte[] unk1; // 0xC - 0x12, 8
-        public uint targetID; // 0x14 - 0x17
-        public byte[] unk2; // 0x18 - 0x1D, 6
-        public ushort instanceID; // 0x1E - 1F
-        public uint sourceID; // 0x20 - 0x23
-        public byte[] unk3; // 0x24 - 0x2B, 8
-        public uint atkID; // 0x2C - 0x2F
-        public int value; // 0x30 - 0x33
-        public byte[] unk4; // 0x34 - 0x43, 16
-        public byte flags; // 0x44
-        public byte[] unk5; // 0x45 - 0x50, 11
+	public class PacketDamage : Packet, ISendPacket
+	{
+		public uint playerID; // 0x8 - 0xB
+		public byte[] unk1; // 0xC - 0x12, 8
+		public uint targetID; // 0x14 - 0x17
+		public byte[] unk2; // 0x18 - 0x1D, 6
+		public ushort instanceID; // 0x1E - 1F
+		public uint sourceID; // 0x20 - 0x23
+		public byte[] unk3; // 0x24 - 0x2B, 8
+		public uint atkID; // 0x2C - 0x2F
+		public int value; // 0x30 - 0x33
+		public byte[] unk4; // 0x34 - 0x43, 16
+		public byte flags; // 0x44
+		public byte[] unk5; // 0x45 - 0x50, 11
 
-        public PacketDamage(byte[] pkt) : base(pkt)
-        {
-            ParseData(data);
-        }
+		public PacketDamage() : base()
+		{
+		}
 
-        protected override void ParseData(byte[] data)
-        {
-            using (BinaryReader reader = new BinaryReader(new MemoryStream(data)))
-            {
-                playerID = reader.ReadUInt32();
-                unk1 = reader.ReadBytes(0x8);
-                targetID = reader.ReadUInt32();
-                unk2 = reader.ReadBytes(0x6);
-                instanceID = reader.ReadUInt16();
-                sourceID = reader.ReadUInt32();
-                unk3 = reader.ReadBytes(0x8);
-                atkID = reader.ReadUInt32();
-                value = reader.ReadInt32();
-                unk4 = reader.ReadBytes(0x10);
-                flags = reader.ReadByte();
-                unk5 = reader.ReadBytes(0x11);
-            }
-        }
-    }
+		public byte[] ConstructPacket(PacketHeader header)
+		{
+			this.header = header;
+			this.data = new byte[0x50 - PacketHeader.HeaderSize];
+
+			using (BinaryWriter writer = new BinaryWriter(new MemoryStream(this.data)))
+			{
+				writer.Write(playerID);
+				writer.Write(unk1);
+				writer.Write(targetID);
+				writer.Write(unk2);
+				writer.Write(instanceID);
+				writer.Write(sourceID);
+				writer.Write(unk3);
+				writer.Write(atkID);
+				writer.Write(value);
+				writer.Write(unk4);
+				writer.Write(flags);
+				writer.Write(unk5);
+			}
+
+			BuildPacket();
+			return this.packet;
+		}
+	}
 }


### PR DESCRIPTION
Previous method was a hack and doesn't make much sense when dealing with sent and received packets.

The plan is we can differentiate both sent and received packets with interfaces, and if it ever happens we can handle a situation where a packet ID does both.

How we write/read packets is still debatable, but let's see how do-able this is as we add more packets.